### PR TITLE
8. Added spring profile "springJpa" - replace all SpringDataJpa repo's with custom Spring ORM + JPA + Hibernate implementation

### DIFF
--- a/src/main/java/com/lig/libby/controller/adapter/adminui/BookController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/adminui/BookController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.adminui.mapper.save.BookUiApiSaveMapper;
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Book;
+import com.lig.libby.repository.BookRepository;
 import com.lig.libby.service.BookService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ class BookController implements GenricUIApiController<Book, String> {
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Book.class, while api request is made for BookDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<Book> findAll(@QuerydslPredicate(root = Book.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<Book> findAll(@QuerydslPredicate(root = Book.class, bindings = BookRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/adminui/CommentController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/adminui/CommentController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.adminui.mapper.save.CommentUiApiSaveMapp
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Comment;
+import com.lig.libby.repository.CommentRepository;
 import com.lig.libby.service.CommentService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ class CommentController implements GenricUIApiController<Comment, String> {
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Comment.class, while api request is made for CommentDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<Comment> findAll(@QuerydslPredicate(root = Comment.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<Comment> findAll(@QuerydslPredicate(root = Comment.class, bindings = CommentRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/adminui/LangController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/adminui/LangController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.adminui.mapper.save.LangUiApiSaveMapper;
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Lang;
+import com.lig.libby.repository.LangRepository;
 import com.lig.libby.service.LangService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ class LangController implements GenricUIApiController<Lang, String> {
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Lang.class, while api request is made for LangDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<Lang> findAll(@QuerydslPredicate(root = Lang.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<Lang> findAll(@QuerydslPredicate(root = Lang.class, bindings = LangRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(
                 service.findAll(predicate, pageable, userDetails)

--- a/src/main/java/com/lig/libby/controller/adapter/adminui/TaskController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/adminui/TaskController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.adminui.mapper.save.TaskUiApiSaveMapper;
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Task;
+import com.lig.libby.repository.TaskRepository;
 import com.lig.libby.service.TaskService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,7 +40,7 @@ class TaskController implements GenricUIApiController<Task, String> {
     //Here we assume that Entity and DTO have:
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Task.class, while api request is made for TaskDto.class
     // 3) bindings = .. is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<Task> findAll(@QuerydslPredicate(root = Task.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<Task> findAll(@QuerydslPredicate(root = Task.class, bindings = TaskRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/adminui/UserController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/adminui/UserController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.adminui.mapper.save.UserUiApiSaveMapper;
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.User;
+import com.lig.libby.repository.UserRepository;
 import com.lig.libby.service.UserService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ class UserController implements GenricUIApiController<User, String> {
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for User.class, while api request is made for UserDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<User> findAll(@QuerydslPredicate(root = User.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<User> findAll(@QuerydslPredicate(root = User.class, bindings = UserRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/userui/BookPublicController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/userui/BookPublicController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.userui.mapper.read.BookPublicUiApiReadMa
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Book;
+import com.lig.libby.repository.BookRepository;
 import com.lig.libby.service.BookService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +41,7 @@ public class BookPublicController implements GenricUIApiController<BookPublicDto
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Book.class, while api request is made for BookDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<BookPublicDto> findAll(@QuerydslPredicate(root = Book.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<BookPublicDto> findAll(@QuerydslPredicate(root = Book.class, bindings = BookRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/userui/CommentPublicController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/userui/CommentPublicController.java
@@ -6,6 +6,7 @@ import com.lig.libby.controller.adapter.userui.mapper.save.CommentPublicUiApiSav
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Comment;
+import com.lig.libby.repository.CommentRepository;
 import com.lig.libby.service.CommentService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +45,7 @@ public class CommentPublicController implements GenricUIApiController<CommentPub
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Comment.class, while api request is made for CommentDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<CommentPublicDto> findAll(@QuerydslPredicate(root = Comment.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<CommentPublicDto> findAll(@QuerydslPredicate(root = Comment.class, bindings = CommentRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/userui/LangPublicController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/userui/LangPublicController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.userui.mapper.read.LangPublicUiApiReadMa
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Lang;
+import com.lig.libby.repository.LangRepository;
 import com.lig.libby.service.LangService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ public class LangPublicController implements GenricUIApiController<LangPublicDto
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Lang.class, while api request is made for LangDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<LangPublicDto> findAll(@QuerydslPredicate(root = Lang.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<LangPublicDto> findAll(@QuerydslPredicate(root = Lang.class, bindings = LangRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/userui/TaskPublicController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/userui/TaskPublicController.java
@@ -6,6 +6,7 @@ import com.lig.libby.controller.adapter.userui.mapper.save.TaskPublicUiApiSaveMa
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.Task;
+import com.lig.libby.repository.TaskRepository;
 import com.lig.libby.service.TaskService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +44,7 @@ public class TaskPublicController implements GenricUIApiController<TaskPublicDto
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for Task.class, while api request is made for TaskDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<TaskPublicDto> findAll(@QuerydslPredicate(root = Task.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<TaskPublicDto> findAll(@QuerydslPredicate(root = Task.class, bindings = TaskRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/controller/adapter/userui/UserPublicController.java
+++ b/src/main/java/com/lig/libby/controller/adapter/userui/UserPublicController.java
@@ -5,6 +5,7 @@ import com.lig.libby.controller.adapter.userui.mapper.read.UserPublicUiApiReadMa
 import com.lig.libby.controller.core.uiadapter.GenricUIApiController;
 import com.lig.libby.domain.Authority;
 import com.lig.libby.domain.User;
+import com.lig.libby.repository.UserRepository;
 import com.lig.libby.service.UserService;
 import com.querydsl.core.types.Predicate;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +39,7 @@ public class UserPublicController implements GenricUIApiController<UserPublicDto
     // 1) same field names (DTO can has only subset) due to @QuerydslPredicate is builded for User.class, while api request is made for UserDto.class
     // 2) Pagination for is not broken during Mapper work (e.g no filtering in mapping process used) due to pageable usage
     // 3) bindings = ... is needed only for @ActiveProfile eq. "springJdbc" and "springJpa" where Repository bean is custom, so does not support bind with repository itself
-    public Page<UserPublicDto> findAll(@QuerydslPredicate(root = User.class) Predicate predicate, Pageable pageable, Authentication authentication) {
+    public Page<UserPublicDto> findAll(@QuerydslPredicate(root = User.class, bindings = UserRepository.class) Predicate predicate, Pageable pageable, Authentication authentication) {
         UserDetails userDetails = (UserDetails) authentication.getPrincipal();
         return readMapper.pageableEntityToDto(service.findAll(predicate, pageable, userDetails));
     }

--- a/src/main/java/com/lig/libby/repository/AuthorityRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/AuthorityRepositoryJpa.java
@@ -1,0 +1,39 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Authority;
+import com.lig.libby.domain.QAuthority;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import com.querydsl.core.BooleanBuilder;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.Iterator;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class AuthorityRepositoryJpa extends GenericQueryDslRepositoryJpa<Authority, QAuthority, String> implements AuthorityRepository {
+
+    public AuthorityRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Authority> getDomainClass() {
+        return Authority.class;
+    }
+
+    @Override
+    public Authority getAuthorityByName(@NonNull String name) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(QAuthority.authority.name.eq(name));
+        Iterator<Authority> iter = findAll(where).iterator();
+        if (iter.hasNext()) {
+            return iter.next();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/BookRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/BookRepositoryJpa.java
@@ -1,0 +1,25 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Book;
+import com.lig.libby.domain.QBook;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class BookRepositoryJpa extends GenericQueryDslRepositoryJpa<Book, QBook, String> implements BookRepository {
+
+    public BookRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Book> getDomainClass() {
+        return Book.class;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/CommentRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/CommentRepositoryJpa.java
@@ -1,0 +1,25 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Comment;
+import com.lig.libby.domain.QComment;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class CommentRepositoryJpa extends GenericQueryDslRepositoryJpa<Comment, QComment, String> implements CommentRepository {
+
+    public CommentRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Comment> getDomainClass() {
+        return Comment.class;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/LangRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/LangRepositoryJpa.java
@@ -1,0 +1,25 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Lang;
+import com.lig.libby.domain.QLang;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class LangRepositoryJpa extends GenericQueryDslRepositoryJpa<Lang, QLang, String> implements LangRepository {
+
+    public LangRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Lang> getDomainClass() {
+        return Lang.class;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/TaskRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/TaskRepositoryJpa.java
@@ -1,0 +1,25 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.QTask;
+import com.lig.libby.domain.Task;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class TaskRepositoryJpa extends GenericQueryDslRepositoryJpa<Task, QTask, String> implements TaskRepository {
+
+    public TaskRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Task> getDomainClass() {
+        return Task.class;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/UserRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/UserRepositoryJpa.java
@@ -1,0 +1,39 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.QUser;
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import com.querydsl.core.BooleanBuilder;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.Iterator;
+import java.util.Optional;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class UserRepositoryJpa extends GenericQueryDslRepositoryJpa<User, QUser, String> implements UserRepository {
+
+    public UserRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<User> getDomainClass() {
+        return User.class;
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(QUser.user.email.eq(email));
+        Iterator<User> iterator = findAll(where).iterator();
+        if (!iterator.hasNext()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(iterator.next());
+    }
+}

--- a/src/main/java/com/lig/libby/repository/WorkRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/WorkRepositoryJpa.java
@@ -1,0 +1,25 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.QWork;
+import com.lig.libby.domain.Work;
+import com.lig.libby.repository.core.jpa.GenericQueryDslRepositoryJpa;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+@ThreadSafe
+@Profile("springJpa")
+@Repository
+public class WorkRepositoryJpa extends GenericQueryDslRepositoryJpa<Work, QWork, String> implements WorkRepository {
+
+    public WorkRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+    }
+
+    @Override
+    public Class<Work> getDomainClass() {
+        return Work.class;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/core/GenericAllMethodsNotSupportedRepository.java
+++ b/src/main/java/com/lig/libby/repository/core/GenericAllMethodsNotSupportedRepository.java
@@ -1,0 +1,178 @@
+package com.lig.libby.repository.core;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GenericAllMethodsNotSupportedRepository<E, Q extends EntityPathBase<E>, I> implements GenericUiApiRepository<E, Q, I> {
+
+    public static final String OPERATION_NOT_SUPPORTED = "Operation not supported";
+
+
+    @Override
+    public Optional<E> findOne(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate, Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(OrderSpecifier<?>... orders) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Page<E> findAll(Predicate predicate, Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public long count(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean exists(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> S save(S entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAll() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAll(Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAllById(Iterable<I> is) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Page<E> findAll(Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public long count() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void delete(E entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends E> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAll() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> saveAll(Iterable<S> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Optional<E> findById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean existsById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void flush() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> S saveAndFlush(S entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteInBatch(Iterable<E> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public E getOne(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> Optional<S> findOne(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> findAll(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> findAll(Example<S> example, Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> Page<S> findAll(Example<S> example, Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> long count(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> boolean exists(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+}

--- a/src/main/java/com/lig/libby/repository/core/jpa/GenericQueryDslRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/core/jpa/GenericQueryDslRepositoryJpa.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2008-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lig.libby.repository.core.jpa;
+
+import com.lig.libby.domain.core.PersistentObject;
+import com.querydsl.core.NonUniqueResultException;
+import com.querydsl.core.types.EntityPath;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.JPQLQuery;
+import com.querydsl.jpa.impl.AbstractJPAQuery;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.support.Querydsl;
+import org.springframework.data.querydsl.EntityPathResolver;
+import org.springframework.data.querydsl.QSort;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.SimpleEntityPathResolver;
+import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+import javax.persistence.EntityManager;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+
+
+public abstract class GenericQueryDslRepositoryJpa<T extends PersistentObject, Q extends EntityPathBase<T>, I extends Serializable> extends GenericRepositoryJpa<T, Q, I>
+        implements QuerydslPredicateExecutor<T> {
+
+    private static final EntityPathResolver DEFAULT_ENTITY_PATH_RESOLVER = SimpleEntityPathResolver.INSTANCE;
+
+    private final EntityPath<T> path;
+    private final PathBuilder<T> builder;
+    private final Querydsl querydsl;
+
+
+    public GenericQueryDslRepositoryJpa(EntityManager entityManager) {
+        super(entityManager);
+        this.path = DEFAULT_ENTITY_PATH_RESOLVER.createPath(getDomainClass());
+        this.builder = new PathBuilder<>(path.getType(), path.getMetadata());
+        this.querydsl = new Querydsl(entityManager, builder);
+
+    }
+
+    @Override
+    public abstract Class<T> getDomainClass();
+
+    @Override
+    public Optional<T> findOne(Predicate predicate) {
+
+        try {
+            return Optional.ofNullable(createQuery(predicate).select(path).fetchOne());
+        } catch (NonUniqueResultException ex) {
+            throw new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, ex);
+        }
+    }
+
+    @Override
+    public List<T> findAll(Predicate predicate) {
+        return createQuery(predicate).select(path).fetch();
+    }
+
+    @Override
+    public List<T> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
+        return executeSorted(createQuery(predicate).select(path), orders);
+    }
+
+    @Override
+    public List<T> findAll(Predicate predicate, Sort sort) {
+
+        Assert.notNull(sort, "Sort must not be null!");
+
+        return executeSorted(createQuery(predicate).select(path), sort);
+    }
+
+    @Override
+    public List<T> findAll(OrderSpecifier<?>... orders) {
+
+        Assert.notNull(orders, "Order specifiers must not be null!");
+
+        return executeSorted(createQuery(new Predicate[0]).select(path), orders);
+    }
+
+    @Override
+    public Page<T> findAll(Predicate predicate, Pageable pageable) {
+
+        Assert.notNull(pageable, "Pageable must not be null!");
+
+        final JPQLQuery<?> countQuery = createCountQuery(predicate);
+        JPQLQuery<T> query = querydsl.applyPagination(pageable, createQuery(predicate).select(path));
+
+        return PageableExecutionUtils.getPage(query.fetch(), pageable, countQuery::fetchCount);
+    }
+
+    @Override
+    public long count(Predicate predicate) {
+        return createQuery(predicate).fetchCount();
+    }
+
+    @Override
+    public boolean exists(Predicate predicate) {
+        return createQuery(predicate).fetchCount() > 0;
+    }
+
+    @SuppressWarnings("squid:S1452")
+    //this is how external library QueryDSL designed - we skip rule "Generic wildcard types should not be used in return parameters" here
+    protected JPQLQuery<?> createQuery(Predicate... predicate) {
+        return doCreateQuery(predicate);
+    }
+
+    @SuppressWarnings("squid:S1452")
+    //this is how external library QueryDSL designed - we skip rule "Generic wildcard types should not be used in return parameters" here
+    protected JPQLQuery<?> createCountQuery(@Nullable Predicate... predicate) {
+        return doCreateQuery(predicate);
+    }
+
+    private AbstractJPAQuery<?, ?> doCreateQuery(@Nullable Predicate... predicate) {
+
+        AbstractJPAQuery<?, ?> query = querydsl.createQuery(path);
+
+        if (predicate != null) {
+            query = query.where(predicate);
+        }
+
+        return query;
+    }
+
+    private List<T> executeSorted(JPQLQuery<T> query, OrderSpecifier<?>... orders) {
+        return executeSorted(query, new QSort(orders));
+    }
+
+    private List<T> executeSorted(JPQLQuery<T> query, Sort sort) {
+        return querydsl.applySorting(sort, query).fetch();
+    }
+}

--- a/src/main/java/com/lig/libby/repository/core/jpa/GenericRepositoryJpa.java
+++ b/src/main/java/com/lig/libby/repository/core/jpa/GenericRepositoryJpa.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2008-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lig.libby.repository.core.jpa;
+
+import com.lig.libby.domain.core.PersistentObject;
+import com.lig.libby.repository.core.GenericAllMethodsNotSupportedRepository;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import javax.persistence.EntityManager;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Root;
+import java.util.List;
+import java.util.Optional;
+
+import static org.springframework.data.jpa.repository.query.QueryUtils.toOrders;
+
+@Repository
+@Transactional(readOnly = true)
+public abstract class GenericRepositoryJpa<T extends PersistentObject, Q extends EntityPathBase<T>, I> extends GenericAllMethodsNotSupportedRepository<T, Q, I> implements JpaRepository<T, I> {
+
+    private static final String ID_MUST_NOT_BE_NULL = "The given id must not be null!";
+    private final EntityManager em;
+
+
+    @Autowired
+    public GenericRepositoryJpa(EntityManager entityManager) {
+        Assert.notNull(entityManager, "EntityManager must not be null!");
+        this.em = entityManager;
+    }
+
+    public abstract Class<T> getDomainClass();
+
+    @Transactional
+    @Override
+    public void deleteById(I id) {
+        Assert.notNull(id, ID_MUST_NOT_BE_NULL);
+        delete(findById(id).orElseThrow(() -> new EmptyResultDataAccessException(
+                String.format("No entity with id %s exists!", id), 1)));
+    }
+
+
+    @Transactional
+    @Override
+    public void delete(T entity) {
+        Assert.notNull(entity, "The entity must not be null!");
+        em.remove(em.contains(entity) ? entity : em.merge(entity));
+    }
+
+    @Override
+    public Optional<T> findById(I id) {
+        Assert.notNull(id, ID_MUST_NOT_BE_NULL);
+        Class<T> domainType = getDomainClass();
+        return Optional.ofNullable(em.find(domainType, id));
+    }
+
+    @Override
+    public List<T> findAll() {
+        Sort sort = Sort.unsorted();
+        Class<T> domainClass = getDomainClass();
+        CriteriaBuilder builder = em.getCriteriaBuilder();
+        CriteriaQuery<T> query = builder.createQuery(domainClass);
+        Root<T> root = query.from(domainClass);
+        query.select(root);
+
+        if (sort.isSorted()) {
+            query.orderBy(toOrders(sort, root, builder));
+        }
+        return em.createQuery(query).getResultList();
+    }
+
+
+    @Transactional
+    @Override
+    public <S extends T> S save(S entity) {
+
+        if (entity.getVersion() == null) {
+            em.persist(entity);
+            return entity;
+        } else {
+            return em.merge(entity);
+        }
+    }
+
+    @Transactional
+    @Override
+    public <S extends T> S saveAndFlush(S entity) {
+        S result = save(entity);
+        flush();
+        return result;
+    }
+
+    @Transactional
+    @Override
+    public void flush() {
+        em.flush();
+    }
+
+    @Transactional
+    @Override
+    public void deleteAll() {
+        findAll().forEach(this::delete);
+    }
+
+    @Transactional
+    @Override
+    public void deleteAll(Iterable<? extends T> entities) {
+        entities.forEach(this::delete);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,11 +53,14 @@ spring:
     driver-class-name: "org.h2.Driver"
   profiles:
     active:
-      - "springDataJpa"
+      - "springJpa"
       - "shellDisabled"
 ---
 spring:
   profiles: "springDataJpa"
+---
+spring:
+  profiles: "springJpa"
 ---
 spring:
   profiles: "springBatch"

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/BookControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/BookControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.BookRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class BookControllerJpaTest extends BookControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.bookRepository instanceof BookRepositoryJpa
+                || AopUtils.getTargetClass(super.bookRepository).equals(BookRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/CommentControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/CommentControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.CommentRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class CommentControllerJpaTest extends CommentControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.commentRepository instanceof CommentRepositoryJpa
+                || AopUtils.getTargetClass(super.commentRepository).equals(CommentRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/LangControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/LangControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.LangRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class LangControllerJpaTest extends LangControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.langRepository instanceof LangRepositoryJpa
+                || AopUtils.getTargetClass(super.langRepository).equals(LangRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/TaskControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/TaskControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.TaskRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class TaskControllerJpaTest extends TaskControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.taskRepository instanceof TaskRepositoryJpa
+                || AopUtils.getTargetClass(super.taskRepository).equals(TaskRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/UserControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/UserControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class UserControllerJpaTest extends UserControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJpa
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/anonymousui/AuthControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/anonymousui/AuthControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.anonymousui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class AuthControllerJpaTest extends AuthControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJpa
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/BookPublicControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/BookPublicControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.BookRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class BookPublicControllerJpaTest extends BookPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.bookRepository instanceof BookRepositoryJpa
+                || AopUtils.getTargetClass(super.bookRepository).equals(BookRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/CommentPublicControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/CommentPublicControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.CommentRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class CommentPublicControllerJpaTest extends CommentPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.commentRepository instanceof CommentRepositoryJpa
+                || AopUtils.getTargetClass(super.commentRepository).equals(CommentRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/TaskPublicControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/TaskPublicControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.TaskRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class TaskPublicControllerJpaTest extends TaskPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.taskRepository instanceof TaskRepositoryJpa
+                || AopUtils.getTargetClass(super.taskRepository).equals(TaskRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/UserPublicControllerJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/UserPublicControllerJpaTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJpa;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJpa"})
+public class UserPublicControllerJpaTest extends UserPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJpa
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJpa.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/AuthorityRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/AuthorityRepositoryJpaTest.java
@@ -1,0 +1,73 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Authority;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({AuthorityRepository.class, AuthorityRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "AuthorityRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthorityRepositoryJpaTest {
+
+    private final AuthorityRepositoryTest authorityRepositoryTest;
+
+    @Autowired
+    public AuthorityRepositoryJpaTest(@NonNull AuthorityRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Authority> entityFactoryAuthority, @NonNull EntityManager em2) {
+        authorityRepositoryTest = new AuthorityRepositoryTest(repository, em, entityFactoryAuthority, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        authorityRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        authorityRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        authorityRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void getAuthorityByNameTest() {
+        authorityRepositoryTest.getAuthorityByName();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(authorityRepositoryTest.repository instanceof AuthorityRepositoryJpa
+                || AopUtils.getTargetClass(authorityRepositoryTest.repository).equals(AuthorityRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("AuthorityRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends AuthorityRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/BookRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/BookRepositoryJpaTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Book;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({BookRepository.class, BookRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "BookRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookRepositoryJpaTest {
+
+    private final BookRepositoryTest bookRepositoryTest;
+
+    @Autowired
+    public BookRepositoryJpaTest(@NonNull BookRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Book> entityFactoryBook, @NonNull EntityManager em2) {
+        bookRepositoryTest = new BookRepositoryTest(repository, em, entityFactoryBook, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        bookRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        bookRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        bookRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(bookRepositoryTest.repository instanceof BookRepositoryJpa
+                || AopUtils.getTargetClass(bookRepositoryTest.repository).equals(BookRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("BookRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends BookRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/CommentRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/CommentRepositoryJpaTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Comment;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({CommentRepository.class, CommentRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "CommentRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryJpaTest {
+
+    private final CommentRepositoryTest commentRepositoryTest;
+
+    @Autowired
+    public CommentRepositoryJpaTest(@NonNull CommentRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Comment> entityFactoryComment, @NonNull EntityManager em2) {
+        commentRepositoryTest = new CommentRepositoryTest(repository, em, entityFactoryComment, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        commentRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        commentRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        commentRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(commentRepositoryTest.repository instanceof CommentRepositoryJpa
+                || AopUtils.getTargetClass(commentRepositoryTest.repository).equals(CommentRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("CommentRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends CommentRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/LangRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/LangRepositoryJpaTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Lang;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({LangRepository.class, LangRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "LangRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LangRepositoryJpaTest {
+
+    private final LangRepositoryTest langRepositoryTest;
+
+    @Autowired
+    public LangRepositoryJpaTest(@NonNull LangRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Lang> entityFactoryLang, @NonNull EntityManager em2) {
+        langRepositoryTest = new LangRepositoryTest(repository, em, entityFactoryLang, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        langRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        langRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        langRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(langRepositoryTest.repository instanceof LangRepositoryJpa
+                || AopUtils.getTargetClass(langRepositoryTest.repository).equals(LangRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("LangRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends LangRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/TaskRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/TaskRepositoryJpaTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Task;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({TaskRepository.class, TaskRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "TaskRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TaskRepositoryJpaTest {
+
+    private final TaskRepositoryTest taskRepositoryTest;
+
+    @Autowired
+    public TaskRepositoryJpaTest(@NonNull TaskRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Task> entityFactoryTask, @NonNull EntityManager em2) {
+        taskRepositoryTest = new TaskRepositoryTest(repository, em, entityFactoryTask, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        taskRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        taskRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        taskRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(taskRepositoryTest.repository instanceof TaskRepositoryJpa
+                || AopUtils.getTargetClass(taskRepositoryTest.repository).equals(TaskRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("TaskRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends TaskRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/UserRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/UserRepositoryJpaTest.java
@@ -1,0 +1,73 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({UserRepository.class, UserRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "UserRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryJpaTest {
+
+    private final UserRepositoryTest userRepositoryTest;
+
+    @Autowired
+    public UserRepositoryJpaTest(@NonNull UserRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<User> entityFactoryUser, @NonNull EntityManager em2) {
+        userRepositoryTest = new UserRepositoryTest(repository, em, entityFactoryUser, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        userRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        userRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        userRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void findByEmailTest() {
+        userRepositoryTest.findByEmail();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(userRepositoryTest.repository instanceof UserRepositoryJpa
+                || AopUtils.getTargetClass(userRepositoryTest.repository).equals(UserRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("UserRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends UserRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/WorkRepositoryJpaTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/WorkRepositoryJpaTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Work;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({WorkRepository.class, WorkRepositoryJpa.class})
+@ActiveProfiles({"shellDisabled", "springJpa", "WorkRepositoryJpaTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WorkRepositoryJpaTest {
+
+    private final WorkRepositoryTest workRepositoryTest;
+
+    @Autowired
+    public WorkRepositoryJpaTest(@NonNull WorkRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Work> entityFactoryWork, @NonNull EntityManager em2) {
+        workRepositoryTest = new WorkRepositoryTest(repository, em, entityFactoryWork, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        workRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        workRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        workRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(workRepositoryTest.repository instanceof WorkRepositoryJpa
+                || AopUtils.getTargetClass(workRepositoryTest.repository).equals(WorkRepositoryJpa.class)
+        ).isTrue();
+    }
+
+    @Profile("WorkRepositoryJpaTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends WorkRepositoryTest.IntegrationTestConfiguration {
+    }
+}


### PR DESCRIPTION
Task#8.

Added spring profile "springJpa" profile - it replaces all springDataJpa repositories with custom implementations made with Spring ORM + JPA + QueryDSL.

Application functionality stay same as with "springDataJpa" profile, but only used in this app repositories methods have realization (others will throw operation not supported exception).