### PR TITLE
6. Added spring profile "springJdbc"

### DIFF
--- a/src/main/java/com/lig/libby/repository/AuthorityRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/AuthorityRepositoryJdbc.java
@@ -1,0 +1,95 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.Authority;
+import com.lig.libby.domain.QAuthority;
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import com.querydsl.core.BooleanBuilder;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+public class AuthorityRepositoryJdbc extends GenericRepositoryJdbc<Authority, QAuthority> implements AuthorityRepository {
+    public static final ImmutableList<ValueFieldMeta<Authority, QAuthority, ?>> authorityValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Authority, QAuthority, ?, ?>> authorityEntityFieldsMeta;
+    public static final String AUTH_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<Authority, QAuthority, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QAuthority.authority.id, Authority.ID_COLUMN, Authority::getId, Authority::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QAuthority.authority.version, Authority.VERSION_COLUMN, Authority::getVersion, Authority::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QAuthority.authority.updatedDate, Authority.UPDATED_DATE_COLUMN, Authority::getUpdatedDate, Authority::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QAuthority.authority.createdDate, Authority.CREATED_DATE_COLUMN, Authority::getCreatedDate, Authority::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QAuthority.authority.name, Authority.NAME_COLUMN, Authority::getName, Authority::setName, String.class));
+
+        authorityValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        final List<EntityFieldMeta<Authority, QAuthority, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QAuthority.authority.createdBy, Authority.CREATED_BY_COLUMN, Authority::getCreatedBy, Authority::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QAuthority.authority.lastUpdBy, Authority.LAST_UPD_BY_COLUMN, Authority::getLastUpdBy, Authority::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        authorityEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        AUTH_SELECT_ALL_COLUMNS_SQL = "select " +
+                authorityValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                authorityEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Authority.TABLE + " " + ValueFieldMeta.aliasQ(QAuthority.authority) +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QAuthority.authority.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QAuthority.authority) + "." + Authority.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QAuthority.authority.createdBy) + "." + User.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QAuthority.authority.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QAuthority.authority) + "." + Authority.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QAuthority.authority.lastUpdBy) + "." + User.ID_COLUMN;
+
+    }
+
+    @Autowired
+    public AuthorityRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(authorityValueFieldsMeta, authorityEntityFieldsMeta, AUTH_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+
+    @Override
+    public String getTable() {
+        return Authority.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Authority.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Authority> getEntityFactory() {
+        return Authority::new;
+    }
+
+    @Override
+    public Authority getAuthorityByName(@NonNull String name) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(QAuthority.authority.name.eq(name));
+        Iterator<Authority> iter = findAll(where).iterator();
+        if (iter.hasNext()) {
+            return iter.next();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/BookRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/BookRepositoryJdbc.java
@@ -1,0 +1,105 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.*;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+@SuppressWarnings("squid:S1192") //ignore "String literals should not be duplicated" rule for jdbc class
+public class BookRepositoryJdbc extends GenericRepositoryJdbc<Book, QBook> implements BookRepository {
+    public static final ImmutableList<ValueFieldMeta<Book, QBook, ?>> bookValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Book, QBook, ?, ?>> bookEntityFieldsMeta;
+    public static final String BOOK_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<Book, QBook, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QBook.book.id, Book.ID_COLUMN, Book::getId, Book::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.version, Book.VERSION_COLUMN, Book::getVersion, Book::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.updatedDate, Book.UPDATED_DATE_COLUMN, Book::getUpdatedDate, Book::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.createdDate, Book.CREATED_DATE_COLUMN, Book::getCreatedDate, Book::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.name, Book.Columns.NAME, Book::getName, Book::setName, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.title, Book.Columns.TITLE, Book::getTitle, Book::setTitle, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.authors, Book.Columns.AUTHORS, Book::getAuthors, Book::setAuthors, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.smallImageUrl, Book.Columns.SMALL_IMAGE_URL, Book::getSmallImageUrl, Book::setSmallImageUrl, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.isbn, Book.Columns.ISBN, Book::getIsbn, Book::setIsbn, String.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.isbn13, Book.Columns.ISBN13, Book::getIsbn13, Book::setIsbn13, BigInteger.class));
+        tmp.add(new ValueFieldMeta<>(QBook.book.originalPublicationYear, Book.Columns.ORIGINAL_PUBLICATION_YEAR, Book::getOriginalPublicationYear, Book::setOriginalPublicationYear, Integer.class));
+
+        String averageRatingFormulaOverride = "(select " +
+                "avg(c." + Comment.Columns.RATING_COLUMN + ") " +
+                "from " + Comment.TABLE + " c  " +
+                "where c." + Comment.Columns.BOOK_ID_COLUMN + " = " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.ID_COLUMN + ") ";
+        tmp.add(new ValueFieldMeta<>(QBook.book.averageRating, averageRatingFormulaOverride, Book::getAverageRating, Book::setAverageRating, Float.class));
+
+        String ratingsCountFormulaOverride = "(select " +
+                " (case when count(1)> 0 then count(1) else null end) " +
+                " from " + Comment.TABLE + " c " +
+                " where c." + Comment.Columns.BOOK_ID_COLUMN + " = " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.ID_COLUMN + " )";
+        tmp.add(new ValueFieldMeta<>(QBook.book.ratingsCount, ratingsCountFormulaOverride, Book::getRatingsCount, Book::setRatingsCount, BigInteger.class));
+
+        bookValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        final List<EntityFieldMeta<Book, QBook, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QBook.book.createdBy, Book.CREATED_BY_COLUMN, Book::getCreatedBy, Book::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QBook.book.lastUpdBy, Book.LAST_UPD_BY_COLUMN, Book::getLastUpdBy, Book::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QBook.book.lang, Book.Columns.LANG_ID, Book::getLang, Book::setLang, LangRepositoryJdbc.langValueFieldsMeta, Lang.class, Lang::new));
+        tmp.add(new EntityFieldMeta<>(QBook.book.work, Book.Columns.WORK_ID, Book::getWork, Book::setWork, WorkRepositoryJdbc.workValueFieldsMeta, Work.class, Work::new));
+
+        bookEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        BOOK_SELECT_ALL_COLUMNS_SQL = "select " +
+                bookValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                bookEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Book.TABLE + " " + ValueFieldMeta.aliasQ(QBook.book) +
+                " left join " + Lang.TABLE + " " + ValueFieldMeta.aliasQ(QBook.book.lang) +
+                " on " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.Columns.LANG_ID + " = " + ValueFieldMeta.aliasQ(QBook.book.lang) + "." + Lang.ID_COLUMN +
+                " left join " + Work.TABLE + " " + ValueFieldMeta.aliasQ(QBook.book.work) +
+                " on " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.Columns.WORK_ID + " = " + ValueFieldMeta.aliasQ(QBook.book.work) + "." + Work.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QBook.book.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QBook.book.createdBy) + "." + User.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QBook.book.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QBook.book) + "." + Book.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QBook.book.lastUpdBy) + "." + User.ID_COLUMN;
+    }
+
+    @Autowired
+    public BookRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(bookValueFieldsMeta, bookEntityFieldsMeta, BOOK_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+    @Override
+    public String getTable() {
+        return Book.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Book.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Book> getEntityFactory() {
+        return Book::new;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/CommentRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/CommentRepositoryJdbc.java
@@ -1,0 +1,88 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.Book;
+import com.lig.libby.domain.Comment;
+import com.lig.libby.domain.QComment;
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+@SuppressWarnings("squid:S1192") //ignore "String literals should not be duplicated" rule for jdbc class
+public class CommentRepositoryJdbc extends GenericRepositoryJdbc<Comment, QComment> implements CommentRepository {
+    public static final ImmutableList<ValueFieldMeta<Comment, QComment, ?>> commentValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Comment, QComment, ?, ?>> commentEntityFieldsMeta;
+    public static final String LANG_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<Comment, QComment, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QComment.comment.id, Comment.ID_COLUMN, Comment::getId, Comment::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QComment.comment.version, Comment.VERSION_COLUMN, Comment::getVersion, Comment::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QComment.comment.updatedDate, Comment.UPDATED_DATE_COLUMN, Comment::getUpdatedDate, Comment::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QComment.comment.createdDate, Comment.CREATED_DATE_COLUMN, Comment::getCreatedDate, Comment::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QComment.comment.body, Comment.Columns.BODY_COLUMN, Comment::getBody, Comment::setBody, String.class));
+        tmp.add(new ValueFieldMeta<>(QComment.comment.rating, Comment.Columns.RATING_COLUMN, Comment::getRating, Comment::setRating, Integer.class));
+        commentValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        final List<EntityFieldMeta<Comment, QComment, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QComment.comment.createdBy, Comment.CREATED_BY_COLUMN, Comment::getCreatedBy, Comment::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QComment.comment.lastUpdBy, Comment.LAST_UPD_BY_COLUMN, Comment::getLastUpdBy, Comment::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QComment.comment.book, Comment.Columns.BOOK_ID_COLUMN, Comment::getBook, Comment::setBook, BookRepositoryJdbc.bookValueFieldsMeta, Book.class, Book::new));
+        commentEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+
+    static {
+        LANG_SELECT_ALL_COLUMNS_SQL = "select " +
+                commentValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                commentEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Comment.TABLE + " " + ValueFieldMeta.aliasQ(QComment.comment) +
+                " left join " + Book.TABLE + " " + ValueFieldMeta.aliasQ(QComment.comment.book) +
+                " on " + ValueFieldMeta.aliasQ(QComment.comment) + "." + Comment.Columns.BOOK_ID_COLUMN + " = " + ValueFieldMeta.aliasQ(QComment.comment.book) + "." + Book.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QComment.comment.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QComment.comment) + "." + Comment.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QComment.comment.createdBy) + "." + User.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QComment.comment.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QComment.comment) + "." + Comment.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QComment.comment.lastUpdBy) + "." + User.ID_COLUMN;
+
+    }
+
+    @Autowired
+    public CommentRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(commentValueFieldsMeta, commentEntityFieldsMeta, LANG_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+
+    @Override
+    public String getTable() {
+        return Comment.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Comment.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Comment> getEntityFactory() {
+        return Comment::new;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/LangRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/LangRepositoryJdbc.java
@@ -1,0 +1,82 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.Lang;
+import com.lig.libby.domain.QLang;
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+public class LangRepositoryJdbc extends GenericRepositoryJdbc<Lang, QLang> implements LangRepository {
+    public static final ImmutableList<ValueFieldMeta<Lang, QLang, ?>> langValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Lang, QLang, ?, ?>> langEntityFieldsMeta;
+    public static final String LANG_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<Lang, QLang, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QLang.lang.id, Lang.ID_COLUMN, Lang::getId, Lang::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QLang.lang.version, Lang.VERSION_COLUMN, Lang::getVersion, Lang::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QLang.lang.updatedDate, Lang.UPDATED_DATE_COLUMN, Lang::getUpdatedDate, Lang::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QLang.lang.createdDate, Lang.CREATED_DATE_COLUMN, Lang::getCreatedDate, Lang::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QLang.lang.code, Lang.NAME_COLUMN, Lang::getCode, Lang::setCode, String.class));
+
+        langValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        final List<EntityFieldMeta<Lang, QLang, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QLang.lang.createdBy, Lang.CREATED_BY_COLUMN, Lang::getCreatedBy, Lang::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QLang.lang.lastUpdBy, Lang.LAST_UPD_BY_COLUMN, Lang::getLastUpdBy, Lang::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        langEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        LANG_SELECT_ALL_COLUMNS_SQL = "select " +
+                langValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                langEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Lang.TABLE + " " + ValueFieldMeta.aliasQ(QLang.lang) +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QLang.lang.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QLang.lang) + "." + Lang.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QLang.lang.createdBy) + "." + User.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QLang.lang.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QLang.lang) + "." + Lang.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QLang.lang.lastUpdBy) + "." + User.ID_COLUMN;
+
+    }
+
+    @Autowired
+    public LangRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(langValueFieldsMeta, langEntityFieldsMeta, LANG_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+
+    @Override
+    public String getTable() {
+        return Lang.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Lang.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Lang> getEntityFactory() {
+        return Lang::new;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/TaskRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/TaskRepositoryJdbc.java
@@ -1,0 +1,104 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.*;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+@SuppressWarnings("squid:S1192") //ignore "String literals should not be duplicated" rule for jdbc class
+public class TaskRepositoryJdbc extends GenericRepositoryJdbc<Task, QTask> implements TaskRepository {
+    public static final ImmutableList<ValueFieldMeta<Task, QTask, ?>> taskValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Task, QTask, ?, ?>> taskEntityFieldsMeta;
+    public static final String BOOK_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<Task, QTask, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QTask.task.id, Task.ID_COLUMN, Task::getId, Task::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.version, Task.VERSION_COLUMN, Task::getVersion, Task::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.updatedDate, Task.UPDATED_DATE_COLUMN, Task::getUpdatedDate, Task::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.createdDate, Task.CREATED_DATE_COLUMN, Task::getCreatedDate, Task::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookName, Task.Columns.BOOK_NAME, Task::getBookName, Task::setBookName, String.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookTitle, Task.Columns.BOOK_TITLE, Task::getBookTitle, Task::setBookTitle, String.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.workflowStep, Task.Columns.WORKFLOW_STEP, Task::getWorkflowStep, Task::setWorkflowStep, Task.WorkflowStepEnum.class));
+
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookIsbn, Task.Columns.BOOK_ISBN, Task::getBookIsbn, Task::setBookIsbn, String.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookIsbn13, Task.Columns.BOOK_ISBN_13, Task::getBookIsbn13, Task::setBookIsbn13, BigInteger.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookSmallImageUrl, Task.Columns.BOOK_SMALL_IMAGE_URL, Task::getBookSmallImageUrl, Task::setBookSmallImageUrl, String.class));
+        tmp.add(new ValueFieldMeta<>(QTask.task.bookAuthors, Task.Columns.BOOK_AUTHORS, Task::getBookAuthors, Task::setBookAuthors, String.class));
+        taskValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        final List<EntityFieldMeta<Task, QTask, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QTask.task.createdBy, Task.CREATED_BY_COLUMN, Task::getCreatedBy, Task::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QTask.task.lastUpdBy, Task.LAST_UPD_BY_COLUMN, Task::getLastUpdBy, Task::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QTask.task.bookLang, Task.Columns.BOOK_LANG_ID, Task::getBookLang, Task::setBookLang, LangRepositoryJdbc.langValueFieldsMeta, Lang.class, Lang::new));
+        tmp.add(new EntityFieldMeta<>(QTask.task.bookWork, Task.Columns.BOOK_WORK_ID, Task::getBookWork, Task::setBookWork, WorkRepositoryJdbc.workValueFieldsMeta, Work.class, Work::new));
+        tmp.add(new EntityFieldMeta<>(QTask.task.assignee, Task.Columns.ASSIGNEE_USER_ID, Task::getAssignee, Task::setAssignee, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QTask.task.book, Task.Columns.BOOK_ID, Task::getBook, Task::setBook, BookRepositoryJdbc.bookValueFieldsMeta, Book.class, Book::new));
+
+        taskEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        BOOK_SELECT_ALL_COLUMNS_SQL = "select " +
+                taskValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                taskEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Task.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task) +
+                " left join " + Lang.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.bookLang) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.Columns.BOOK_LANG_ID + " = " + ValueFieldMeta.aliasQ(QTask.task.bookLang) + "." + Lang.ID_COLUMN +
+
+                " left join " + Work.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.bookWork) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.Columns.BOOK_WORK_ID + " = " + ValueFieldMeta.aliasQ(QTask.task.bookWork) + "." + Work.ID_COLUMN +
+
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QTask.task.createdBy) + "." + User.ID_COLUMN +
+
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QTask.task.lastUpdBy) + "." + User.ID_COLUMN +
+
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.assignee) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.Columns.ASSIGNEE_USER_ID + " = " + ValueFieldMeta.aliasQ(QTask.task.assignee) + "." + User.ID_COLUMN +
+        
+                " left join " + Book.TABLE + " " + ValueFieldMeta.aliasQ(QTask.task.book) +
+                " on " + ValueFieldMeta.aliasQ(QTask.task) + "." + Task.Columns.BOOK_ID + " = " + ValueFieldMeta.aliasQ(QTask.task.book) + "." + Book.ID_COLUMN;
+    }
+
+    @Autowired
+    public TaskRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(taskValueFieldsMeta, taskEntityFieldsMeta, BOOK_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+    @Override
+    public String getTable() {
+        return Task.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Task.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Task> getEntityFactory() {
+        return Task::new;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/UserRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/UserRepositoryJdbc.java
@@ -1,0 +1,210 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.Authority;
+import com.lig.libby.domain.QUser;
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import com.querydsl.core.BooleanBuilder;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+@SuppressWarnings("squid:S1192") //ignore "String literals should not be duplicated" rule for jdbc class
+public class UserRepositoryJdbc extends GenericRepositoryJdbc<User, QUser> implements UserRepository {
+    public static final ImmutableList<ValueFieldMeta<User, QUser, ?>> userValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<User, QUser, ?, ?>> userEntityFieldsMeta;
+    public static final String USER_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        final List<ValueFieldMeta<User, QUser, ?>> tmp = new ArrayList<>();
+        tmp.add(new ValueFieldMeta<>(QUser.user.id, User.ID_COLUMN, User::getId, User::setId, String.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.version, User.VERSION_COLUMN, User::getVersion, User::setVersion, Integer.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.createdDate, User.CREATED_DATE_COLUMN, User::getCreatedDate, User::setCreatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.updatedDate, User.UPDATED_DATE_COLUMN, User::getUpdatedDate, User::setUpdatedDate, Long.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.name, User.Columns.NAME_COLUMN, User::getName, User::setName, String.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.email, User.Columns.EMAIL_COLUMN, User::getEmail, User::setEmail, String.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.password, User.Columns.PASSWORD_COLUMN, User::getPassword, User::setPassword, String.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.emailVerified, User.Columns.EMAIL_VERIFIED_COLUMN, User::getEmailVerified, User::setEmailVerified, Boolean.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.provider, User.Columns.PROVIDER_COLUMN, User::getProvider, User::setProvider, Authority.AuthProvider.class));
+        tmp.add(new ValueFieldMeta<>(QUser.user.imageUrl, User.Columns.IMAGE_URL_COLUMN, User::getImageUrl, User::setImageUrl, String.class));
+
+        userValueFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        List<EntityFieldMeta<User, QUser, ?, ?>> tmp = new ArrayList<>();
+
+        tmp.add(new EntityFieldMeta<>(QUser.user.createdBy, User.CREATED_BY_COLUMN, User::getCreatedBy, User::setCreatedBy, userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QUser.user.lastUpdBy, User.LAST_UPD_BY_COLUMN, User::getLastUpdBy, User::setLastUpdBy, userValueFieldsMeta, User.class, User::new));
+        userEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        USER_SELECT_ALL_COLUMNS_SQL = "select " +
+                userValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                userEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + User.TABLE + " " + ValueFieldMeta.aliasQ(QUser.user) +
+
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QUser.user.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QUser.user) + "." + User.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QUser.user.createdBy) + "." + User.ID_COLUMN +
+
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QUser.user.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QUser.user) + "." + User.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QUser.user.lastUpdBy) + "." + User.ID_COLUMN;
+
+    }
+
+    @Autowired
+    public UserRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(userValueFieldsMeta, userEntityFieldsMeta, USER_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+
+    @Override
+    public String getTable() {
+        return User.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return User.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<User> getEntityFactory() {
+        return User::new;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<User> findByEmail(String email) {
+        BooleanBuilder where = new BooleanBuilder();
+        where.and(QUser.user.email.eq(email));
+        Iterator<User> iterator = findAll(where).iterator();
+        if (!iterator.hasNext()) {
+            return Optional.empty();
+        }
+
+        User user = iterator.next();
+        List<Authority> userAuthorities = findManyToManyAuthoritiesByUser(user);
+        user.setAuthorities(new HashSet<>(userAuthorities));
+        return Optional.ofNullable(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public User findFirstWithAdminAuthority() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("adminAuthority", Authority.Roles.ADMIN);
+        String userId = jdbcOp.query(" select " +
+                        "  ua." + User.USER_AUTHORITY_JOIN_TABLE_USER_FK_COLUMN + " as ua_user_id " +
+                        " from " + User.USER_AUTHORITY_JOIN_TABLE + " ua" +
+                        " left join " + Authority.TABLE + " a " +
+                        " on a." + Authority.ID_COLUMN + "= ua." + User.USER_AUTHORITY_JOIN_TABLE_AUTHORITY_FK_COLUMN +
+                        " where a." + Authority.NAME_COLUMN + "=:adminAuthority"
+                , params
+                , (resultSet, i) -> resultSet.getString("ua_user_id")).stream().findFirst().orElse(null);
+        return userId == null ? null : this.findById(userId).orElse(null);
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public <S extends User> S save(S entity) {
+        S entitySaved = super.save(entity);
+        this.saveManyToManyAuthoritiesByUser(entity);
+        entitySaved.setAuthorities(entity.getAuthorities());
+        return entitySaved;
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public <S extends User> S saveAndFlush(S entity) {
+        return this.save(entity);
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(@NonNull String s) {
+        Map<String, String> params = new HashMap<>();
+        params.put("userId", s);
+        jdbcOp.update(" DELETE FROM " + User.USER_AUTHORITY_JOIN_TABLE + " ua " +
+                        " WHERE ua." + User.USER_AUTHORITY_JOIN_TABLE_USER_FK_COLUMN + "=:userId"
+                , params);
+        super.deleteById(s);
+    }
+
+    @NotNull
+    private List<Authority> findManyToManyAuthoritiesByUser(User user) {
+        return jdbcOp.query(" select " +
+                        "  a." + Authority.ID_COLUMN + " as a_id " +
+                        ", a." + Authority.VERSION_COLUMN + " as a_version " +
+                        ", a." + Authority.NAME_COLUMN + " as a_name " +
+                        " from " + User.USER_AUTHORITY_JOIN_TABLE + " ua" +
+                        " left join " + Authority.TABLE + " a " +
+                        " on a." + Authority.ID_COLUMN + "= ua." + User.USER_AUTHORITY_JOIN_TABLE_AUTHORITY_FK_COLUMN +
+                        " where ua." + User.USER_AUTHORITY_JOIN_TABLE_USER_FK_COLUMN + " = \'" + user.getId() + "\'"
+                , new HashMap<>()
+                , (resultSet, i) -> {
+                    Authority authority = new Authority();
+                    authority.setId(resultSet.getString("a_id"));
+                    authority.setName(resultSet.getString("a_name"));
+                    authority.setVersion(GenericRepositoryJdbc.getNullableInt(resultSet, "a_version"));
+                    return authority;
+                });
+    }
+
+    @NotNull
+    private void saveManyToManyAuthoritiesByUser(User user) {
+        Set<Authority> newAuthorities = user.getAuthorities();
+        Set<Authority> currentAuthorities = new HashSet<>(findManyToManyAuthoritiesByUser(user));
+
+        Set<Authority> toInsertAuthorities = newAuthorities.stream()
+                .distinct()
+                .filter(o -> !currentAuthorities.contains(o))
+                .collect(Collectors.toSet());
+
+        if (!toInsertAuthorities.isEmpty()) {
+            jdbcOp.update(" INSERT INTO " + User.USER_AUTHORITY_JOIN_TABLE +
+                            " ( " + User.USER_AUTHORITY_JOIN_TABLE_USER_FK_COLUMN +
+                            " , " + User.USER_AUTHORITY_JOIN_TABLE_AUTHORITY_FK_COLUMN +
+                            " ) " +
+                            " values " +
+                            toInsertAuthorities.stream().map(a -> "(\'" + user.getId() + "\',\'" + a.getId() + "\')").collect(Collectors.joining(","))
+                    , new HashMap<String, Object>()
+            );
+        }
+
+        Set<Authority> toDeleteAuthorities = currentAuthorities.stream()
+                .distinct()
+                .filter(o -> !currentAuthorities.contains(o))
+                .collect(Collectors.toSet());
+
+        if (!toDeleteAuthorities.isEmpty()) {
+            jdbcOp.update(" DELETE FROM " + User.USER_AUTHORITY_JOIN_TABLE +
+                            " where " + User.USER_AUTHORITY_JOIN_TABLE_USER_FK_COLUMN + "=\'" + user.getId() + "\'" +
+                            " and " + User.USER_AUTHORITY_JOIN_TABLE_AUTHORITY_FK_COLUMN + " IN " +
+                            "(" +
+                            toDeleteAuthorities.stream().map(a -> "\'" + a.getId() + "\'").collect(Collectors.joining(",")) +
+                            ")"
+                    , new HashMap<String, Object>()
+            );
+        }
+    }
+
+}

--- a/src/main/java/com/lig/libby/repository/WorkRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/WorkRepositoryJdbc.java
@@ -1,0 +1,81 @@
+package com.lig.libby.repository;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.QWork;
+import com.lig.libby.domain.User;
+import com.lig.libby.domain.Work;
+import com.lig.libby.repository.core.jdbc.EntityFieldMeta;
+import com.lig.libby.repository.core.jdbc.GenericRepositoryJdbc;
+import com.lig.libby.repository.core.jdbc.ValueFieldMeta;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@Repository
+public class WorkRepositoryJdbc extends GenericRepositoryJdbc<Work, QWork> implements WorkRepository {
+    public static final ImmutableList<ValueFieldMeta<Work, QWork, ?>> workValueFieldsMeta;
+    public static final ImmutableList<EntityFieldMeta<Work, QWork, ?, ?>> workEntityFieldsMeta;
+    public static final String WORK_SELECT_ALL_COLUMNS_SQL;
+
+    static {
+        List<ValueFieldMeta<Work, QWork, ?>> workMetha = new ArrayList<>();
+        workMetha.add(new ValueFieldMeta<>(QWork.work.id, Work.ID_COLUMN, Work::getId, Work::setId, String.class));
+        workMetha.add(new ValueFieldMeta<>(QWork.work.version, Work.VERSION_COLUMN, Work::getVersion, Work::setVersion, Integer.class));
+        workMetha.add(new ValueFieldMeta<>(QWork.work.updatedDate, Work.UPDATED_DATE_COLUMN, Work::getUpdatedDate, Work::setUpdatedDate, Long.class));
+        workMetha.add(new ValueFieldMeta<>(QWork.work.createdDate, Work.CREATED_DATE_COLUMN, Work::getCreatedDate, Work::setCreatedDate, Long.class));
+        workValueFieldsMeta = ImmutableList.copyOf(workMetha);
+    }
+
+
+    static {
+        List<EntityFieldMeta<Work, QWork, ?, ?>> tmp = new ArrayList<>();
+        tmp.add(new EntityFieldMeta<>(QWork.work.createdBy, Work.CREATED_BY_COLUMN, Work::getCreatedBy, Work::setCreatedBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        tmp.add(new EntityFieldMeta<>(QWork.work.lastUpdBy, Work.LAST_UPD_BY_COLUMN, Work::getLastUpdBy, Work::setLastUpdBy, UserRepositoryJdbc.userValueFieldsMeta, User.class, User::new));
+        workEntityFieldsMeta = ImmutableList.copyOf(tmp);
+    }
+
+    static {
+        WORK_SELECT_ALL_COLUMNS_SQL = "select " +
+                workValueFieldsMeta.stream().map(ValueFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                ", " +
+                workEntityFieldsMeta.stream().map(EntityFieldMeta::getFieldSelectSQLFragment).flatMap(Collection::stream).collect(Collectors.joining(" ,")) +
+                " from " + Work.TABLE + " " + ValueFieldMeta.aliasQ(QWork.work) +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QWork.work.createdBy) +
+                " on " + ValueFieldMeta.aliasQ(QWork.work) + "." + Work.CREATED_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QWork.work.createdBy) + "." + User.ID_COLUMN +
+                " left join " + User.TABLE + " " + ValueFieldMeta.aliasQ(QWork.work.lastUpdBy) +
+                " on " + ValueFieldMeta.aliasQ(QWork.work) + "." + Work.LAST_UPD_BY_COLUMN + " = " + ValueFieldMeta.aliasQ(QWork.work.lastUpdBy) + "." + User.ID_COLUMN;
+
+    }
+
+    @Autowired
+    public WorkRepositoryJdbc(@NonNull NamedParameterJdbcOperations jdbcOp) {
+        super(workValueFieldsMeta, workEntityFieldsMeta, WORK_SELECT_ALL_COLUMNS_SQL, jdbcOp);
+    }
+
+
+    @Override
+    public String getTable() {
+        return Work.TABLE;
+    }
+
+    @Override
+    public String getIdColumn() {
+        return Work.ID_COLUMN;
+    }
+
+    @Override
+    public Supplier<Work> getEntityFactory() {
+        return Work::new;
+    }
+}

--- a/src/main/java/com/lig/libby/repository/core/GenericAllMethodsNotSupportedRepository.java
+++ b/src/main/java/com/lig/libby/repository/core/GenericAllMethodsNotSupportedRepository.java
@@ -1,0 +1,178 @@
+package com.lig.libby.repository.core;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GenericAllMethodsNotSupportedRepository<E, Q extends EntityPathBase<E>, I> implements GenericUiApiRepository<E, Q, I> {
+
+    public static final String OPERATION_NOT_SUPPORTED = "Operation not supported";
+
+
+    @Override
+    public Optional<E> findOne(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate, Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(Predicate predicate, OrderSpecifier<?>... orders) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Iterable<E> findAll(OrderSpecifier<?>... orders) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Page<E> findAll(Predicate predicate, Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public long count(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean exists(Predicate predicate) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> S save(S entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAll() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAll(Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public List<E> findAllById(Iterable<I> is) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Page<E> findAll(Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public long count() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void delete(E entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends E> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAll() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> saveAll(Iterable<S> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public Optional<E> findById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public boolean existsById(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void flush() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> S saveAndFlush(S entity) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteInBatch(Iterable<E> entities) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public E getOne(I i) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> Optional<S> findOne(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> findAll(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> List<S> findAll(Example<S> example, Sort sort) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> Page<S> findAll(Example<S> example, Pageable pageable) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> long count(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+
+    @Override
+    public <S extends E> boolean exists(Example<S> example) {
+        throw new RuntimeException(OPERATION_NOT_SUPPORTED);
+    }
+}

--- a/src/main/java/com/lig/libby/repository/core/jdbc/EntityFieldMeta.java
+++ b/src/main/java/com/lig/libby/repository/core/jdbc/EntityFieldMeta.java
@@ -1,0 +1,50 @@
+package com.lig.libby.repository.core.jdbc;
+
+import com.lig.libby.domain.core.PersistentObject;
+import com.querydsl.core.types.Path;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import org.hibernate.annotations.Formula;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+public class EntityFieldMeta<E extends PersistentObject, Q extends Path<E>, R extends PersistentObject, K extends Path<R>> extends ValueFieldMeta<E, Q, R> {
+    @NonNull
+    private final List<ValueFieldMeta<R, K, ?>> childMetha;
+    @NonNull
+    private final Supplier<R> fieldClassFactory;
+
+    public EntityFieldMeta(@NonNull Path<R> fieldAlias, @NonNull String fieldColumn, @NonNull Function<E, R> fieldGetter, @NonNull BiConsumer<E, R> fieldSetter, @NonNull List<ValueFieldMeta<R, K, ?>> childMetha, @NonNull Class<R> fieldClass, @NonNull Supplier<R> fieldClassFactory) {
+        super(fieldAlias, fieldColumn, fieldGetter, fieldSetter, fieldClass);
+        this.childMetha = childMetha;
+        this.fieldClassFactory = fieldClassFactory;
+    }
+
+    @Override
+    public List<String> getFieldSelectSQLFragment() {
+        return childMetha
+                .stream()
+                .map(cField ->
+                        {
+                            String childFieldParentAlias = this.getFieldParentAlias() + "_" + this.getFieldName();
+                            if (cField.getFieldAlias().getAnnotatedElement().isAnnotationPresent(Formula.class)) {
+                                return Arrays.asList(" null as " + childFieldParentAlias + "_" + cField.getFieldName());//formula in child entities is not supported
+                            }
+                            return Arrays.asList(childFieldParentAlias + "." + cField.getFieldColumn() + " as " + childFieldParentAlias + "_" + cField.getFieldName());
+                        }
+                )
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/com/lig/libby/repository/core/jdbc/GenericRepositoryJdbc.java
+++ b/src/main/java/com/lig/libby/repository/core/jdbc/GenericRepositoryJdbc.java
@@ -1,0 +1,345 @@
+package com.lig.libby.repository.core.jdbc;
+
+import com.google.common.collect.ImmutableList;
+import com.lig.libby.domain.core.AbstractPersistentObject;
+import com.lig.libby.domain.core.GenericAbstractPersistentAuditingObject;
+import com.lig.libby.domain.core.PersistentObject;
+import com.lig.libby.repository.core.GenericAllMethodsNotSupportedRepository;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import lombok.NonNull;
+import net.jcip.annotations.ThreadSafe;
+import org.hibernate.annotations.Formula;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.math.BigInteger;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+@ThreadSafe
+@Profile("springJdbc")
+@SuppressWarnings("squid:S1192") //ignore "String literals should not be duplicated" rule for jdbc class
+public abstract class GenericRepositoryJdbc<E extends PersistentObject, Q extends EntityPathBase<E>> extends GenericAllMethodsNotSupportedRepository<E, Q, String> {
+
+    @NonNull
+    public final ImmutableList<ValueFieldMeta<E, Q, ?>> valueFieldsMeta;
+    @NonNull
+    public final ImmutableList<EntityFieldMeta<E, Q, ?, ?>> entityFieldsMeta;
+    @NonNull
+    public final String selectAllColumnsSql;
+    @NonNull
+    public final RowMapper<E> entityMapper;
+    @NonNull
+    public final NamedParameterJdbcOperations jdbcOp;
+
+    public GenericRepositoryJdbc(@NonNull ImmutableList<ValueFieldMeta<E, Q, ?>> valueFieldsMeta, @NonNull ImmutableList<EntityFieldMeta<E, Q, ?, ?>> entityFieldsMeta, @NonNull String selectAllColumnsSql, @NonNull NamedParameterJdbcOperations jdbcOp) {
+        this.valueFieldsMeta = valueFieldsMeta;
+        this.entityFieldsMeta = entityFieldsMeta;
+        this.selectAllColumnsSql = selectAllColumnsSql;
+        this.jdbcOp = jdbcOp;
+        this.entityMapper = new EntityMapper();
+    }
+
+    public static Long getNullableLong(ResultSet resultSet, String columnLabel) throws SQLException {
+        return resultSet.getString(columnLabel) == null ? null : resultSet.getLong(columnLabel);
+    }
+
+    public static Integer getNullableInt(ResultSet resultSet, String columnLabel) throws SQLException {
+        return resultSet.getString(columnLabel) == null ? null : resultSet.getInt(columnLabel);
+    }
+
+    public static BigInteger getNullableBigInteger(ResultSet resultSet, String columnLabel) throws SQLException {
+        return resultSet.getString(columnLabel) == null ? null : resultSet.getBigDecimal(columnLabel).toBigInteger();
+    }
+
+    public static Float getNullableFloat(ResultSet resultSet, String columnLabel) throws SQLException {
+        return resultSet.getString(columnLabel) == null ? null : resultSet.getFloat(columnLabel);
+    }
+
+    public static Boolean getNullableBoolean(ResultSet resultSet, String columnLabel) throws SQLException {
+        return resultSet.getString(columnLabel) == null ? null : resultSet.getBoolean(columnLabel);
+    }
+
+    public abstract Supplier<E> getEntityFactory();
+
+    public abstract String getTable();
+
+    public abstract String getIdColumn();
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public <S extends E> S saveAndFlush(S entity) {
+        return this.save(entity);
+    }
+
+    @Override
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public <S extends E> S save(S entity) {
+        List<ValueFieldMeta<E, Q, ?>> updatableValueFields = valueFieldsMeta.stream().filter(f -> !f.getFieldAlias().getAnnotatedElement().isAnnotationPresent(Formula.class)).collect(Collectors.toList());
+        final Map<String, Object> params2 = new HashMap<>(1);
+        Optional<E> entityCurrent = findById(entity.getId());
+        updatableValueFields.forEach(
+                field -> {
+                    if (AbstractPersistentObject.VERSION_COLUMN.equals(field.getFieldColumn())) {
+                        entity.setVersion(Optional.ofNullable(entity.getVersion()).map(v -> (entityCurrent.isPresent() ? v + 1 : 0)).orElse(0));
+                        params2.put(AbstractPersistentObject.VERSION_COLUMN, entity.getVersion());
+                    } else if (field.getFieldClass().isEnum()) {
+                        Object fieldValue = field.getFieldGetter().apply(entity);
+                        Enum typedFieldValue = (Enum) fieldValue;
+                        params2.put(field.getFieldColumn(), typedFieldValue.name());
+                    } else {
+                        Object fieldValue = field.getFieldGetter().apply(entity);
+                        params2.put(field.getFieldColumn(), fieldValue);
+                    }
+                });
+
+        entityFieldsMeta.forEach(field -> {
+            PersistentObject childFieldValue = field.getFieldGetter().apply(entity);
+            String childFieldIdString = Optional.ofNullable(childFieldValue).map(PersistentObject::getId).orElse(null);
+            if (GenericAbstractPersistentAuditingObject.CREATED_BY_COLUMN.equals(field.getFieldColumn()) && !entityCurrent.isPresent()) {
+                params2.put(field.getFieldColumn(), getAuthUserId().orElse(childFieldIdString));
+            } else if (GenericAbstractPersistentAuditingObject.LAST_UPD_BY_COLUMN.equals(field.getFieldColumn())) {
+                params2.put(field.getFieldColumn(), getAuthUserId().orElse(childFieldIdString));
+            } else {
+                params2.put(field.getFieldColumn(), childFieldIdString);
+            }
+        });
+
+        if (entityCurrent.isPresent()) {
+            jdbcOp.update("UPDATE " + getTable() +
+                            " set" +
+                            updatableValueFields.stream().map(f -> " " + f.getFieldColumn() + " =:" + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " ," +
+                            entityFieldsMeta.stream().map(f -> " " + f.getFieldColumn() + " =:" + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " where " + getIdColumn() + " = :" + getIdColumn()
+                    , params2);
+        } else {
+            jdbcOp.update("INSERT INTO " + getTable() +
+                            " (" +
+                            updatableValueFields.stream().map(f -> " " + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " ," +
+                            entityFieldsMeta.stream().map(f -> " " + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " ) " +
+                            " values" +
+                            " (" +
+                            updatableValueFields.stream().map(f -> " :" + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " ," +
+                            entityFieldsMeta.stream().map(f -> " :" + f.getFieldColumn()).collect(Collectors.joining(",")) +
+                            " )"
+                    , params2);
+        }
+        return (S) findById(entity.getId()).orElse(null); //TODO>>dirty>>refactor
+    }
+
+    private Optional<String> getAuthUserId() {
+        SecurityContext securityContext = SecurityContextHolder.getContext();
+        return Optional.ofNullable(securityContext.getAuthentication())
+                .map(authentication -> {
+                    if (authentication.getPrincipal() instanceof UserDetails) {
+                        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+                        return userDetails.getUsername();
+                    }
+                    return null;
+                });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Iterable<E> findAll(Predicate predicate) {
+        HashMap<String, Object> constantsBinding = new HashMap<>();
+        String predicateString = predicate.accept(new QueryDslToStringVisitor(constantsBinding), QueryDslTemplates.DEFAULT);
+        String predicateWhereClause = (("".equals(predicateString)) ? "" : " where " + predicateString + " ");
+
+        return jdbcOp.query("select * from (" + selectAllColumnsSql + ") " + predicateWhereClause
+                , constantsBinding
+                , entityMapper);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<E> findAll(Predicate predicate, Pageable pageable) {
+        Assert.notNull(pageable, "Pageable must not be null!");
+
+        HashMap<String, Object> constantsBinding = new HashMap<>();
+        String predicateString = predicate != null ? predicate.accept(new QueryDslToStringVisitor(constantsBinding), QueryDslTemplates.DEFAULT) : null;
+        String predicateWhereClause = (("".equals(predicateString)) || predicateString == null ? "" : " where " + predicateString + " ");
+
+        String parentAlias = this.getIdFieldMetha().getFieldParentAlias();
+        String pageableSortString = pageable.getSort().stream()
+                .map(s -> " " + parentAlias + "_" + s.getProperty().replace(".", "_") + " " + s.getDirection() + " ")
+                .collect(Collectors.joining(",", "", ""));
+
+        String pageableSortClause = ("".equals(pageableSortString)) || pageableSortString == null ? "" : " ORDER BY " + pageableSortString + " ";
+        constantsBinding.put("offset", pageable.getOffset());
+        constantsBinding.put("pageSize", pageable.getPageSize());
+
+        List<E> query = jdbcOp.query(" select * from (" + selectAllColumnsSql + ") " + predicateWhereClause + pageableSortClause +
+                        " OFFSET :offset ROWS " +
+                        " FETCH NEXT :pageSize ROWS ONLY "
+                , constantsBinding
+                , entityMapper);
+
+
+        LongSupplier countSupplier = () -> {
+            List<Long> count = jdbcOp.query(" select count(1) as count from (select *  from (" + selectAllColumnsSql + ") " + predicateWhereClause + ")"
+                    , constantsBinding
+                    , (resultSet, i) -> resultSet.getLong("count"));
+            return count.stream().findFirst().orElse(0L);
+        };
+
+        return PageableExecutionUtils.getPage(query, pageable, countSupplier);
+    }
+
+    @Override
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRED, isolation = Isolation.READ_COMMITTED)
+    public Optional<E> findById(@NonNull String s) {
+        final Map<String, Object> params = new HashMap<>(1);
+
+        ValueFieldMeta<E, Q, ?> idFieldMetha = getIdFieldMetha();
+
+        params.put(idFieldMetha.getFieldAliasString(), s);
+        return jdbcOp.query(selectAllColumnsSql +
+                        " where " + idFieldMetha.getFieldParentAlias() + "." + idFieldMetha.getFieldColumn() + " = :" + idFieldMetha.getFieldAliasString()
+                , params
+                , entityMapper)
+                .stream()
+                .findFirst();
+    }
+
+    private ValueFieldMeta<E, Q, ?> getIdFieldMetha() {
+        return valueFieldsMeta
+                .stream()
+                .filter(f -> f.getFieldColumn().equals(getIdColumn()))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    @Override
+    @Transactional
+    public void deleteAll() {
+        jdbcOp.update(" DELETE FROM " + getTable()
+                , new HashMap<String, Object>()
+        );
+    }
+
+    @Transactional
+    @Override
+    public void deleteAll(Iterable<? extends E> entities) {
+        entities.forEach(e -> this.deleteById(e.getId()));
+    }
+
+    @Override
+    @Transactional
+    public void deleteById(@NonNull String s) {
+        final Map<String, Object> params = new HashMap<>(1);
+
+        ValueFieldMeta<E, Q, ?> idFieldMetha = valueFieldsMeta
+                .stream()
+                .filter(f -> f.getFieldColumn().equals(getIdColumn()))
+                .findFirst()
+                .orElseThrow(IllegalArgumentException::new);
+
+        params.put(idFieldMetha.getFieldAliasString(), s);
+
+        jdbcOp.update(" DELETE FROM " + getTable() + " " + idFieldMetha.getFieldParentAlias() +
+                        " WHERE " + idFieldMetha.getFieldParentAlias() + "." + idFieldMetha.getFieldColumn() + " = :" + idFieldMetha.getFieldAliasString()
+                , params);
+    }
+
+    public <T extends Object> void readValueFieldMapper(@NonNull ResultSet resultSet, T entity, ValueFieldMeta<?, ?, ?> field, String fieldAlias) {
+        try {
+            fieldAlias = (fieldAlias != null ? fieldAlias : "");
+            @NonNull BiConsumer<T, Object> typedSetter = (BiConsumer<T, Object>) field.getFieldSetter();
+            @NonNull Class<?> clazz = field.getFieldClass();
+
+            if (clazz.isAssignableFrom(String.class)) {
+                typedSetter.accept(entity, resultSet.getString(fieldAlias));
+            } else if (clazz.isAssignableFrom(Integer.class)) {
+                typedSetter.accept(entity, getNullableInt(resultSet, fieldAlias));
+            } else if (clazz.isAssignableFrom(Long.class)) {
+                typedSetter.accept(entity, getNullableLong(resultSet, fieldAlias));
+            } else if (clazz.isAssignableFrom(BigInteger.class)) {
+                typedSetter.accept(entity, getNullableBigInteger(resultSet, fieldAlias));
+            } else if (clazz.isAssignableFrom(Float.class)) {
+                typedSetter.accept(entity, getNullableFloat(resultSet, fieldAlias));
+            } else if (clazz.isAssignableFrom(Boolean.class)) {
+                typedSetter.accept(entity, getNullableBoolean(resultSet, fieldAlias));
+            } else if (clazz.isEnum()) {
+                if (resultSet.getString(fieldAlias) == null) {
+                    typedSetter.accept(entity, null);
+                } else {
+                    typedSetter.accept(entity, Enum.valueOf((Class<Enum>) clazz, resultSet.getString(fieldAlias)));
+                }
+
+            } else {
+                throw (new RuntimeException("Type " + field.getFieldClass() + " is not supported in jdbc read mapper"));
+            }
+        } catch (SQLException e) {
+            throw (new RuntimeException(e));
+        }
+    }
+
+    public <E> void acceptObject(BiConsumer<E, ?> biConsumer, E entity, Object argument) {
+        BiConsumer<E, Object> typedBiConsumer = (BiConsumer<E, Object>) biConsumer;
+        typedBiConsumer.accept(entity, argument);
+    }
+
+    public class EntityMapper implements RowMapper<E> {
+        @Override
+        public E mapRow(@NonNull ResultSet resultSet, int i) throws SQLException {
+
+            E entity = getEntityFactory().get();
+
+            valueFieldsMeta
+                    .forEach(
+                            valueField ->
+                                    readValueFieldMapper(resultSet, entity, valueField, valueField.getFieldAliasString())
+                    );
+
+            entityFieldsMeta
+                    .forEach(
+                            persistentObjectField -> {
+                                ValueFieldMeta<?, ?, ?> idFieldMetha = persistentObjectField.getChildMetha()
+                                        .stream()
+                                        .filter(f -> f.getFieldColumn().equals(AbstractPersistentObject.ID_COLUMN))//TODO>>IBORISENKO>>fix, that this will not work for PresistentObject not extended from AbstractPersistentObject
+                                        .findFirst()
+                                        .orElseThrow(IllegalArgumentException::new);
+                                try {
+                                    if (resultSet.getString(persistentObjectField.getFieldParentAlias() + "_" + persistentObjectField.getFieldName() + "_" + idFieldMetha.getFieldName()) != null) {
+                                        Object childEntity = persistentObjectField.getFieldClassFactory().get();
+                                        persistentObjectField.getChildMetha().forEach(valueField -> {
+                                                    readValueFieldMapper(resultSet, childEntity, valueField, persistentObjectField.getFieldParentAlias() + "_" + persistentObjectField.getFieldName() + "_" + valueField.getFieldName());
+                                                    acceptObject(persistentObjectField.getFieldSetter(), entity, childEntity);
+                                                }
+                                        );
+                                    }
+                                } catch (SQLException e) {
+                                    throw (new RuntimeException("Error retrieving field" + idFieldMetha.getFieldAliasString()));
+                                }
+
+                            });
+            return entity;
+        }
+    }
+
+}

--- a/src/main/java/com/lig/libby/repository/core/jdbc/QueryDslTemplates.java
+++ b/src/main/java/com/lig/libby/repository/core/jdbc/QueryDslTemplates.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lig.libby.repository.core.jdbc;
+
+import com.querydsl.core.types.*;
+
+import java.util.Arrays;
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+public class QueryDslTemplates extends com.querydsl.core.types.Templates {
+
+    public static final QueryDslTemplates DEFAULT = new QueryDslTemplates();
+    private final Map<Operator, Template> templates = new IdentityHashMap<>(150);
+    private final Map<Operator, Integer> precedence = new IdentityHashMap<>(150);
+    private final TemplateFactory templateFactory;
+    private final char escape;
+
+    protected QueryDslTemplates() {
+        this('\\');
+    }
+
+    protected QueryDslTemplates(char escape) {
+        this.escape = escape;
+        templateFactory = new TemplateFactory(escape) {
+            @Override
+            public String escapeForLike(String str) {
+                return QueryDslTemplates.this.escapeForLike(str);
+            }
+        };
+
+        add(Ops.LIST, "{0}, {1}", Precedence.LIST);
+        add(Ops.SET, "{0}, {1}", Precedence.LIST);
+        add(Ops.SINGLETON, "{0}", Precedence.LIST);
+        add(Ops.WRAPPED, "({0})");
+        add(Ops.ORDER, "order()");
+
+        add(Ops.AND, "{0} and {1}");
+        add(Ops.NOT, "not {0}", Precedence.NOT);
+        add(Ops.OR, "{0} or {1}");
+
+        // comparison
+        add(Ops.BETWEEN, "{0} between {1} and {2}", Precedence.COMPARISON);
+        add(Ops.GOE, "{0} >= {1}", Precedence.COMPARISON);
+        add(Ops.GT, "{0} > {1}", Precedence.COMPARISON);
+        add(Ops.LOE, "{0} <= {1}", Precedence.COMPARISON);
+        add(Ops.LT, "{0} < {1}", Precedence.COMPARISON);
+
+        // various
+        add(Ops.EQ, "{0} = {1}", Precedence.EQUALITY);
+        add(Ops.EQ_IGNORE_CASE, "{0l} = {1l}");
+        add(Ops.NE, "{0} != {1}", Precedence.EQUALITY);
+
+
+        add(Ops.IN, "{0} in ({1})", Templates.Precedence.COMPARISON);
+        add(Ops.NOT_IN, "{0} not in ({1})", Templates.Precedence.COMPARISON);
+        add(Ops.ALIAS, "{0} as {1}", 0);
+
+        add(Ops.IS_NULL, "{0} is null", Precedence.COMPARISON);
+        add(Ops.IS_NOT_NULL, "{0} is not null", Precedence.COMPARISON);
+
+        add(Ops.LIKE_IC, "{0l} like {1l}", Precedence.COMPARISON);
+        add(Ops.LIKE_ESCAPE, "{0} like {1} escape '{2s}'", Precedence.COMPARISON);
+        add(Ops.LIKE_ESCAPE_IC, "{0l} like {1l} escape '{2s}'", Precedence.COMPARISON);
+
+        add(Ops.LIKE, "{0} like {1} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.ENDS_WITH, "{0} like {%1} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.ENDS_WITH_IC, "{0l} like {%%1} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.STARTS_WITH, "{0} like {1%} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.STARTS_WITH_IC, "{0l} like {1%%} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.STRING_CONTAINS, "{0} like {%1%} escape '" + escape + "'", Precedence.COMPARISON);
+        add(Ops.STRING_CONTAINS_IC, "{0l} like {%%1%%} escape '" + escape + "'", Precedence.COMPARISON);
+
+
+        // path types
+        add(PathType.PROPERTY, "{0}_{1s}");
+        add(PathType.VARIABLE, "{0s}");
+        add(PathType.DELEGATE, "{0}");
+
+        for (PathType type : new PathType[]{
+                PathType.LISTVALUE,
+                PathType.MAPVALUE,
+                PathType.MAPVALUE_CONSTANT}) {
+            add(type, "{0}.get({1})");
+        }
+        add(PathType.ARRAYVALUE, "{0}({1})");
+        add(PathType.COLLECTION_ANY, "any5({0})");
+
+        add(PathType.LISTVALUE_CONSTANT, "{0}.get({1s})"); // serialized constant
+        add(PathType.ARRAYVALUE_CONSTANT, "{0}({1s})");    // serialized constant
+    }
+
+    @Override
+    protected String escapeForLike(String str) {
+        final StringBuilder rv = new StringBuilder(str.length() + 3);
+        for (char ch : str.toCharArray()) {
+            if (ch == escape || ch == '%' || ch == '_') {
+                rv.append(escape);
+            }
+            rv.append(ch);
+        }
+        return rv.toString();
+    }
+
+    @Override
+    protected void setPrecedence(int p, Operator... ops) {
+        setPrecedence(p, Arrays.asList(ops));
+    }
+
+    @Override
+    protected void setPrecedence(int p, Iterable<? extends Operator> ops) {
+        for (Operator op : ops) {
+            precedence.put(op, p);
+        }
+    }
+
+    protected static class Precedence {
+        public static final int HIGHEST = -1;
+        public static final int DOT = 5;
+        public static final int NOT_HIGH = 10;
+        public static final int NEGATE = 20;
+        public static final int ARITH_HIGH = 30;
+        public static final int ARITH_LOW = 40;
+        public static final int COMPARISON = 50;
+        public static final int EQUALITY = 60;
+        public static final int CASE = 70;
+        public static final int LIST = CASE;
+        public static final int NOT = 80;
+        public static final int AND = 90;
+        public static final int XOR = 100;
+        public static final int XNOR = XOR;
+        public static final int OR = 110;
+        private Precedence() {
+            throw new IllegalStateException("Utility class");
+        }
+    }
+
+}

--- a/src/main/java/com/lig/libby/repository/core/jdbc/QueryDslToStringVisitor.java
+++ b/src/main/java/com/lig/libby/repository/core/jdbc/QueryDslToStringVisitor.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2015, The Querydsl Team (http://www.querydsl.com/team)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.lig.libby.repository.core.jdbc;
+
+import com.querydsl.core.types.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * {@code QueryDslToStringVisitor} is used for toString() serialization in {@link Expression} implementations.
+ *
+ * @author tiwe
+ */
+public final class QueryDslToStringVisitor implements Visitor<String, Templates> {
+
+    private final Map<String, Object> constants;
+
+    public QueryDslToStringVisitor(Map<String, Object> constants) {
+        this.constants = constants;
+    }
+
+    @NotNull
+    private static String getConstantWithJdbcBindings(Object element, Map<String, Object> constants) {
+        String stringBase64 = Base64.getUrlEncoder().encodeToString(element.toString().getBytes()).replace("=", "");
+        constants.put(stringBase64, element.toString());
+        return stringBase64;
+    }
+
+    @Override
+    public String visit(Constant<?> e, Templates templates) {
+        if (List.class.isAssignableFrom(e.getType())) {
+            List<Object> eList = (List<Object>) e.getConstant();
+            return eList.stream().map(element -> getConstantWithJdbcBindings(element, constants)).collect(Collectors.joining(", :", " :", " "));
+        } else {
+            return " :" + getConstantWithJdbcBindings(e.getConstant(), constants) + " ";
+        }
+    }
+
+    @Override
+    public String visit(FactoryExpression<?> e, Templates templates) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("new ").append(e.getType().getSimpleName()).append("(");
+        boolean first = true;
+        for (Expression<?> arg : e.getArgs()) {
+            if (!first) {
+                builder.append(", ");
+            }
+            builder.append(arg.accept(this, templates));
+            first = false;
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+
+    @Override
+    @SuppressWarnings({"squid:S3776", "squid:S1066"}) //this method is copy-paste from Visitor (QueryDSL library)
+    public String visit(Operation<?> o, Templates templates) {
+        final Template template = templates.getTemplate(o.getOperator());
+        if (template != null) {
+            final int precedence = templates.getPrecedence(o.getOperator());
+            final StringBuilder builder = new StringBuilder();
+            for (Template.Element element : template.getElements()) {
+                final Object rv = element.convert(o.getArgs());
+                if (rv instanceof Expression) {
+                    if (precedence > -1 && rv instanceof Operation) {
+                        if (precedence < templates.getPrecedence(((Operation<?>) rv).getOperator())) {
+                            builder.append("(");
+                            builder.append(((Expression<?>) rv).accept(this, templates));
+                            builder.append(")");
+                            continue;
+                        }
+                    }
+                    builder.append(((Expression<?>) rv).accept(this, templates));
+                } else {
+                    builder.append(rv.toString());
+                }
+            }
+            return builder.toString();
+        } else {
+            return "unknown operation with operator " + o.getOperator().name() + " and args " + o.getArgs();
+        }
+    }
+
+    @Override
+    public String visit(ParamExpression<?> param, Templates templates) {
+        return "{" + param.getName() + "}";
+    }
+
+    @Override
+    public String visit(Path<?> p, Templates templates) {
+        final Path<?> parent = p.getMetadata().getParent();
+        final Object elem = p.getMetadata().getElement();
+        if (parent != null) {
+            Template pattern = templates.getTemplate(p.getMetadata().getPathType());
+            if (pattern != null) {
+                final List<?> args = Arrays.asList(parent, elem);
+                final StringBuilder builder = new StringBuilder();
+                for (Template.Element element : pattern.getElements()) {
+                    Object rv = element.convert(args);
+                    if (rv instanceof Expression) {
+                        builder.append(((Expression<?>) rv).accept(this, templates));
+                    } else {
+                        builder.append(rv.toString());
+                    }
+                }
+                return builder.toString();
+            } else {
+                throw new IllegalArgumentException("No pattern for " + p.getMetadata().getPathType());
+            }
+        } else {
+            return elem.toString();
+        }
+    }
+
+    @Override
+    public String visit(SubQueryExpression<?> expr, Templates templates) {
+        return expr.getMetadata().toString();
+    }
+
+    @Override
+    public String visit(TemplateExpression<?> expr, Templates templates) {
+        final StringBuilder builder = new StringBuilder();
+        for (Template.Element element : expr.getTemplate().getElements()) {
+            Object rv = element.convert(expr.getArgs());
+            if (rv instanceof Expression) {
+                builder.append(((Expression<?>) rv).accept(this, templates));
+            } else {
+                builder.append(rv.toString());
+            }
+        }
+        return builder.toString();
+    }
+
+}

--- a/src/main/java/com/lig/libby/repository/core/jdbc/ValueFieldMeta.java
+++ b/src/main/java/com/lig/libby/repository/core/jdbc/ValueFieldMeta.java
@@ -1,0 +1,55 @@
+package com.lig.libby.repository.core.jdbc;
+
+import com.lig.libby.domain.core.PersistentObject;
+import com.querydsl.core.types.Path;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.Formula;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+public class ValueFieldMeta<E extends PersistentObject, Q extends Path<E>, R> {
+
+    @NonNull
+    private final Path<R> fieldAlias;
+    //can be null for @Formula fields
+    private final String fieldColumn;
+    @NonNull
+    private final Function<E, R> fieldGetter;
+    @NonNull
+    private final BiConsumer<E, R> fieldSetter;
+    @NonNull
+    private final Class<R> fieldClass;
+
+    public static String aliasQ(Path path) {
+        return path.toString().replace(".", "_");
+    }
+
+    public String getFieldParentAlias() {
+        return aliasQ(Objects.requireNonNull(fieldAlias.getMetadata().getParent()));
+    }
+
+    public String getFieldName() {
+        return fieldAlias.getMetadata().getElement().toString();
+    }
+
+    public String getFieldAliasString() {
+        return this.getFieldParentAlias() + "_" + this.getFieldName();
+    }
+
+    public List<String> getFieldSelectSQLFragment() {
+        if (this.fieldAlias.getAnnotatedElement().isAnnotationPresent(Formula.class)) {
+            return Arrays.asList(this.fieldColumn + " as " + this.getFieldAliasString());
+        }
+        return Arrays.asList(this.getFieldParentAlias() + "." + this.fieldColumn + " as " + this.getFieldAliasString());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,11 +53,14 @@ spring:
     driver-class-name: "org.h2.Driver"
   profiles:
     active:
-      - "springDataJpa"
+      - "springJdbc"
       - "shellDisabled"
 ---
 spring:
   profiles: "springDataJpa"
+---
+spring:
+  profiles: "springJdbc"
 ---
 spring:
   profiles: "springBatch"

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/BookControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/BookControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.BookRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class BookControllerJdbcTest extends BookControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.bookRepository instanceof BookRepositoryJdbc
+                || AopUtils.getTargetClass(super.bookRepository).equals(BookRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/CommentControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/CommentControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.CommentRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class CommentControllerJdbcTest extends CommentControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.commentRepository instanceof CommentRepositoryJdbc
+                || AopUtils.getTargetClass(super.commentRepository).equals(CommentRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/LangControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/LangControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.LangRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class LangControllerJdbcTest extends LangControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.langRepository instanceof LangRepositoryJdbc
+                || AopUtils.getTargetClass(super.langRepository).equals(LangRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/TaskControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/TaskControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.TaskRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class TaskControllerJdbcTest extends TaskControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.taskRepository instanceof TaskRepositoryJdbc
+                || AopUtils.getTargetClass(super.taskRepository).equals(TaskRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/adminui/UserControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/adminui/UserControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.adminui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class UserControllerJdbcTest extends UserControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJdbc
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/anonymousui/AuthControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/anonymousui/AuthControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.anonymousui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class AuthControllerJdbcTest extends AuthControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJdbc
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/BookPublicControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/BookPublicControllerJdbcTest.java
@@ -1,0 +1,27 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.controller.adapter.adminui.BookControllerTest;
+import com.lig.libby.repository.BookRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class BookPublicControllerJdbcTest extends BookPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.bookRepository instanceof BookRepositoryJdbc
+                || AopUtils.getTargetClass(super.bookRepository).equals(BookRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/CommentPublicControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/CommentPublicControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.CommentRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class CommentPublicControllerJdbcTest extends CommentPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.commentRepository instanceof CommentRepositoryJdbc
+                || AopUtils.getTargetClass(super.commentRepository).equals(CommentRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/LangPublicControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/LangPublicControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.LangRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class LangPublicControllerJdbcTest extends LangPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.langRepository instanceof LangRepositoryJdbc
+                || AopUtils.getTargetClass(super.langRepository).equals(LangRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/TaskPublicControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/TaskPublicControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.TaskRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class TaskPublicControllerJdbcTest extends TaskPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.taskRepository instanceof TaskRepositoryJdbc
+                || AopUtils.getTargetClass(super.taskRepository).equals(TaskRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/controller/adapter/userui/UserPublicControllerJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/controller/adapter/userui/UserPublicControllerJdbcTest.java
@@ -1,0 +1,26 @@
+package com.lig.libby.controller.adapter.userui;
+
+import com.lig.libby.Main;
+import com.lig.libby.repository.UserRepositoryJdbc;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, classes = {Main.class})
+@ActiveProfiles({"shellDisabled", "springJdbc"})
+public class UserPublicControllerJdbcTest extends UserPublicControllerTest {
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(super.userRepository instanceof UserRepositoryJdbc
+                || AopUtils.getTargetClass(super.userRepository).equals(UserRepositoryJdbc.class)
+        ).isTrue();
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/AuthorityRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/AuthorityRepositoryJdbcTest.java
@@ -1,0 +1,73 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Authority;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({AuthorityRepository.class, AuthorityRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "AuthorityRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class AuthorityRepositoryJdbcTest {
+
+    private final AuthorityRepositoryTest authorityRepositoryTest;
+
+    @Autowired
+    public AuthorityRepositoryJdbcTest(@NonNull AuthorityRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Authority> entityFactoryAuthority, @NonNull EntityManager em2) {
+        authorityRepositoryTest = new AuthorityRepositoryTest(repository, em, entityFactoryAuthority, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        authorityRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        authorityRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        authorityRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void getAuthorityByNameTest() {
+        authorityRepositoryTest.getAuthorityByName();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(authorityRepositoryTest.repository instanceof AuthorityRepositoryJdbc
+                || AopUtils.getTargetClass(authorityRepositoryTest.repository).equals(AuthorityRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("AuthorityRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends AuthorityRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/BookRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/BookRepositoryJdbcTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Book;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({BookRepository.class, BookRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "BookRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class BookRepositoryJdbcTest {
+
+    private final BookRepositoryTest bookRepositoryTest;
+
+    @Autowired
+    public BookRepositoryJdbcTest(@NonNull BookRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Book> entityFactoryBook, @NonNull EntityManager em2) {
+        bookRepositoryTest = new BookRepositoryTest(repository, em, entityFactoryBook, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        bookRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        bookRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        bookRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(bookRepositoryTest.repository instanceof BookRepositoryJdbc
+                || AopUtils.getTargetClass(bookRepositoryTest.repository).equals(BookRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("BookRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends BookRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/CommentRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/CommentRepositoryJdbcTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Comment;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({CommentRepository.class, CommentRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "CommentRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentRepositoryJdbcTest {
+
+    private final CommentRepositoryTest commentRepositoryTest;
+
+    @Autowired
+    public CommentRepositoryJdbcTest(@NonNull CommentRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Comment> entityFactoryComment, @NonNull EntityManager em2) {
+        commentRepositoryTest = new CommentRepositoryTest(repository, em, entityFactoryComment, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        commentRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        commentRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        commentRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(commentRepositoryTest.repository instanceof CommentRepositoryJdbc
+                || AopUtils.getTargetClass(commentRepositoryTest.repository).equals(CommentRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("CommentRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends CommentRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/LangRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/LangRepositoryJdbcTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Lang;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({LangRepository.class, LangRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "LangRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class LangRepositoryJdbcTest {
+
+    private final LangRepositoryTest langRepositoryTest;
+
+    @Autowired
+    public LangRepositoryJdbcTest(@NonNull LangRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Lang> entityFactoryLang, @NonNull EntityManager em2) {
+        langRepositoryTest = new LangRepositoryTest(repository, em, entityFactoryLang, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        langRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        langRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        langRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(langRepositoryTest.repository instanceof LangRepositoryJdbc
+                || AopUtils.getTargetClass(langRepositoryTest.repository).equals(LangRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("LangRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends LangRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/TaskRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/TaskRepositoryJdbcTest.java
@@ -1,0 +1,68 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Task;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({TaskRepository.class, TaskRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "TaskRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class TaskRepositoryJdbcTest {
+
+    private final TaskRepositoryTest taskRepositoryTest;
+
+    @Autowired
+    public TaskRepositoryJdbcTest(@NonNull TaskRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Task> entityFactoryTask, @NonNull EntityManager em2) {
+        taskRepositoryTest = new TaskRepositoryTest(repository, em, entityFactoryTask, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        taskRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        taskRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        taskRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(taskRepositoryTest.repository instanceof TaskRepositoryJdbc
+                || AopUtils.getTargetClass(taskRepositoryTest.repository).equals(TaskRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("TaskRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends TaskRepositoryTest.IntegrationTestConfiguration {
+    }
+}

--- a/src/test-integration/java/com/lig/libby/repository/UserRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/UserRepositoryJdbcTest.java
@@ -1,0 +1,75 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.User;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({UserRepository.class, UserRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "UserRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryJdbcTest {
+
+    private final UserRepositoryTest userRepositoryTest;
+
+    @Autowired
+    public UserRepositoryJdbcTest(@NonNull UserRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<User> entityFactoryUser, @NonNull EntityManager em2) {
+        userRepositoryTest = new UserRepositoryTest(repository, em, entityFactoryUser, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        userRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        userRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        userRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    void findByEmail() {
+        userRepositoryTest.findByEmail();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(userRepositoryTest.repository instanceof UserRepositoryJdbc
+                || AopUtils.getTargetClass(userRepositoryTest.repository).equals(UserRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("UserRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends UserRepositoryTest.IntegrationTestConfiguration {
+    }
+
+
+}

--- a/src/test-integration/java/com/lig/libby/repository/WorkRepositoryJdbcTest.java
+++ b/src/test-integration/java/com/lig/libby/repository/WorkRepositoryJdbcTest.java
@@ -1,0 +1,70 @@
+package com.lig.libby.repository;
+
+import com.lig.libby.domain.Work;
+import com.lig.libby.repository.common.DataJpaAuditConfig;
+import com.lig.libby.repository.common.EntityFactory;
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.context.annotation.FilterType.ASSIGNABLE_TYPE;
+
+@TestPropertySource(properties = {"spring.batch.job.enabled=false"})
+@ExtendWith(SpringExtension.class)
+@DataJpaTest(includeFilters = @ComponentScan.Filter(type = ASSIGNABLE_TYPE, classes = {DataJpaAuditConfig.class}))
+@Import({WorkRepository.class, WorkRepositoryJdbc.class})
+@ActiveProfiles({"shellDisabled", "springJdbc", "WorkRepositoryJdbcTest"})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class WorkRepositoryJdbcTest {
+
+    private final WorkRepositoryTest workRepositoryTest;
+
+    @Autowired
+    public WorkRepositoryJdbcTest(@NonNull WorkRepository repository, @NonNull TestEntityManager em, @NonNull EntityFactory<Work> entityFactoryWork, @NonNull EntityManager em2) {
+        workRepositoryTest = new WorkRepositoryTest(repository, em, entityFactoryWork, em2);
+    }
+
+    @Test
+    public void saveAndQueryTest() {
+        workRepositoryTest.saveAndQueryTest();
+    }
+
+    @Test
+    public void updateAndQueryTest() {
+        workRepositoryTest.updateAndQueryTest();
+    }
+
+    @Test
+    public void findWithPredicateTest() {
+        workRepositoryTest.findWithPredicateTest();
+    }
+
+    @Test
+    public void testRepositoryInterfaceImplementationAutowiring() {
+        assertThat(workRepositoryTest.repository instanceof WorkRepositoryJdbc
+                || AopUtils.getTargetClass(workRepositoryTest.repository).equals(WorkRepositoryJdbc.class)
+        ).isTrue();
+    }
+
+    @Profile("WorkRepositoryJdbcTest")
+    @TestConfiguration
+    static class IntegrationTestConfiguration extends WorkRepositoryTest.IntegrationTestConfiguration {
+    }
+
+
+}


### PR DESCRIPTION
Added spring profile "springJdbc". Turning on this profile replaces all springDataJpa repositories with custom implementations made with Spring Jdbc + QueryDSL.

Application functionality stay same as with "springDataJpa" profile, but only used in this app repositories methods have realization (others will throw operation not supported exception).

Only simple QueryDSL queries are supported (for example subqueries are not supported and so on).

This PR should be considered only as illustration of inconvenience of Spring Jdbc usage for classical CRUD API